### PR TITLE
Default UV version to empty

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -9,7 +9,7 @@ inputs:
   version:
     description: "Version of UV"
     required: false
-    default: "0.6.3"
+    default: ""
 
 runs:
   using: "composite"


### PR DESCRIPTION
This then will fallback to setup-uv logic of taking the value from pyproject.toml