### PR TITLE
Adopt latest version of GitHub Actions cache

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -39,7 +39,7 @@ runs:
         shared-key: "shared" # To allow reuse across jobs
 
     - name: Rust Compile Cache
-      uses: mozilla-actions/sccache-action@v0.0.6
+      uses: mozilla-actions/sccache-action@v0.0.8
       if: ${{ inputs.sccache == 'true' }}
 
     - name: Rust Compile Cache Config


### PR DESCRIPTION
https://github.com/Mozilla-Actions/sccache-action/releases/tag/v0.0.8

https://github.com/mozilla/sccache/issues/2330

Apparently GitHub dropped support minor cache client versions before 4.2.0 and 3.4.0. We're using mozilla/sccache pinned to an old version that is broken. Supposedly mozilla/sccache release 0.0.8 fixes this.