### PR TITLE
Split rust cache

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "Enable sccache"
     required: false
     default: "true"
+  shared_key:
+    description: "Shared key for caching across jobs"
+    required: false
+    default: "shared" # To allow reuse across jobs
 
 runs:
   using: "composite"
@@ -36,7 +40,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref_name == 'develop' }}
-        shared-key: "shared" # To allow reuse across jobs
+        shared-key: ${{ inputs.shared_key }}
 
     - name: Rust Compile Cache
       uses: mozilla-actions/sccache-action@v0.0.9


### PR DESCRIPTION
Clippy is slow and I think that's because of the shared key:

1. We run CI in spral db
2. `cargo tests` finishes first
3. it uploads the cache (with no results of clippy) to "shared"
4. `clippy` finishes
5. it tries to write the case - but get a rejection as cache already exists
6. next time we run `clippy` from scratch 

Proof: https://github.com/spiraldb/spiraldb/pull/1959: first run was `7m 22s` but the second one was `3m 22s`