### PR TITLE
Version for install action to make it easier for renovate

### DIFF
--- a/.github/actions/lint-toml/action.yml
+++ b/.github/actions/lint-toml/action.yml
@@ -5,7 +5,9 @@ runs:
   using: "composite"
   steps:
     - name: Install taplo
-      uses: taiki-e/install-action@taplo
+      uses: taiki-e/install-action@v2
+      with:
+        tool: taplo
 
     - name: Run taplo-cli
       shell: bash


### PR DESCRIPTION
I suspect renovate is having a problem with this action because it doesn't have a digest or a tagged release.