### PR TITLE
Default to prune uv's cache only on develop

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -9,7 +9,7 @@ inputs:
   prune-cache:
     description: "Prune cache before save"
     required: false
-    default: "true"
+    default: ${{ github.ref == 'refs/heads/develop' }}
   version:
     description: "Version of UV"
     required: false


### PR DESCRIPTION
At this point we never use long-living runners, so we only want to prune the cache before we save it (which should only be on `develop`).

Some more details about how cache pruning behaves in CI - https://docs.astral.sh/uv/concepts/cache/#caching-in-continuous-integration